### PR TITLE
Fix initialization and database utility

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
+++ b/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
@@ -18,16 +18,15 @@ public class PaperDiscord extends JavaPlugin {
     // We'll store references to our auto-posted messages so we can delete them on shutdown
     private Message embedMessage;
     private Message lastUpdatedMessage;
+    private DatabaseManager dbManager;
 
     @Override
     public void onEnable() {
+        // Ensure config exists before reading values
+        saveDefaultConfig();
 
         dbManager = new DatabaseManager(this);
-        discordCommandListener = new DiscordCommandListener(this, db);
-        discordCommandListener.startBot();
-
-        saveDefaultConfig();
-        discordCommandListener = new DiscordCommandListener(this);
+        discordCommandListener = new DiscordCommandListener(this, dbManager);
         discordCommandListener.startBot();
 
         // Delay to allow JDA to initialize before starting updaters


### PR DESCRIPTION
## Summary
- Fix plugin startup by creating Discord listener after saving config
- Introduce DatabaseManager POJOs and `getPlayerStatsByName`
- Clean up plugin to shut down database properly

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b557f026cc832f8cb667170560bd8f