### PR TITLE
Add stats leaderboard command

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
+++ b/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
@@ -62,6 +62,7 @@ public class PaperDiscord extends JavaPlugin {
                         "resetperk",
                         "serverstatus",
                         "stats",
+                        "statsleaderboard",
                         "serverstatusembed",
                         "banformat");
                 for (net.dv8tion.jda.api.interactions.commands.Command command : existingCommands) {


### PR DESCRIPTION
## Summary
- implement `/statsleaderboard` to show top players for chosen stat
- add database helper for fetching top players and register command

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d796f3bc832fadf6272f16a30854